### PR TITLE
Fix duplicate require_lowercase in password_policy variable

### DIFF
--- a/_variables.tf
+++ b/_variables.tf
@@ -260,7 +260,6 @@ variable "password_policy" {
   type = object({
     minimum_length                   = number,
     require_lowercase                = bool,
-    require_lowercase                = bool,
     require_numbers                  = bool,
     require_symbols                  = bool,
     require_uppercase                = bool,


### PR DESCRIPTION
Line 263 had duplicate 'require_lowercase' field causing Terraform error: 'Object constructor map keys must be unique'

Removed the duplicate line to fix the validation error.


Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...